### PR TITLE
Add width slider and camera preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,8 +23,13 @@
     background: #fff;
     padding: 10px;
   }
-  canvas, video {
+  canvas {
     display: none;
+  }
+  video {
+    display: none;
+    max-width: 100%;
+    margin-top: 10px;
   }
 </style>
 </head>
@@ -33,6 +38,8 @@
 <div id="controls">
   <input type="file" id="imageInput" accept="image/*" />
   <button id="startCamera">Start Camera</button>
+  <label for="sizeSlider">Width:</label>
+  <input type="range" id="sizeSlider" min="50" max="800" value="200" />
 </div>
 <div id="emojiCanvas"></div>
 <video id="video" autoplay></video>
@@ -62,15 +69,27 @@ const colorEmojis = [
 const video = document.getElementById('video');
 const imageInput = document.getElementById('imageInput');
 const startCamera = document.getElementById('startCamera');
+const sizeSlider = document.getElementById('sizeSlider');
 const emojiDiv = document.getElementById('emojiCanvas');
 const hiddenCanvas = document.getElementById('hiddenCanvas');
 const ctx = hiddenCanvas.getContext('2d');
 let streaming = false;
 
+// set initial emoji art width based on slider value
+emojiDiv.style.width = sizeSlider.value + 'px';
+
+sizeSlider.addEventListener('input', () => {
+  emojiDiv.style.width = sizeSlider.value + 'px';
+  if (hiddenCanvas.width > 0 && hiddenCanvas.height > 0) {
+    processCanvas();
+  }
+});
+
 startCamera.addEventListener('click', async () => {
   try {
     const stream = await navigator.mediaDevices.getUserMedia({ video: true });
     video.srcObject = stream;
+    video.style.display = 'block';
     streaming = true;
     requestAnimationFrame(updateFrame);
   } catch (e) {
@@ -126,7 +145,8 @@ function getClosestEmoji(color) {
 
 function processCanvas() {
   emojiDiv.innerHTML = '';
-  const numX = Math.floor(emojiDiv.clientWidth / EMOJI_SIZE);
+  if (hiddenCanvas.width === 0 || hiddenCanvas.height === 0) return;
+  const numX = Math.max(1, Math.floor(emojiDiv.clientWidth / EMOJI_SIZE));
   const cellSize = hiddenCanvas.width / numX;
   const numY = Math.ceil(hiddenCanvas.height / cellSize);
   emojiDiv.style.fontSize = EMOJI_SIZE + 'px';


### PR DESCRIPTION
## Summary
- add range slider to control width of emoji art area
- show camera preview once started
- keep emoji canvas hidden until camera starts or image is loaded
- update canvas size when slider changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685977a9b16c8320b4fa7c505b9dcfa6