### PR TITLE
feat: add deep research news fetch and vector store

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,13 +8,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+      - name: Install dependencies
+        run: pip install openai
       - name: Fetch news
         run: python scripts/fetch_news.py
+      - name: Update vector store
+        run: python scripts/update_vector_store.py
       - name: Deduplicate
         run: python scripts/dedup_and_link.py
       - name: Generate daily index

--- a/README.md
+++ b/README.md
@@ -27,3 +27,11 @@ the daily index, and commits the changes back to the repository.
 
 The frontend is plain HTML/CSS/JS and can be previewed locally by serving the
 `public/` directory with any static file server.
+
+## OpenAI Setup
+
+The automation requires access to OpenAI's **Deep Research** API and the
+`text-embedding-3-small` model.  Locally, set the `OPENAI_API_KEY` environment
+variable.  For GitHub Actions, create a repository secret named
+`OPENAI_API_KEY`.  Ensure that your OpenAI account has browsing and Deep
+Research enabled.

--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -4,20 +4,49 @@ from __future__ import annotations
 import json
 import os
 from datetime import datetime
+from typing import Any, Dict, List
 
-# Placeholder implementation
+from openai import OpenAI
+
+
+client = OpenAI()
+
+
+def fetch_news() -> List[Dict[str, Any]]:
+    """Use the Deep Research API to retrieve today's news.
+
+    The model is instructed to return a JSON object with an ``items`` list.
+    Each item should contain ``id``, ``title``, ``date``, ``content`` and
+    ``sources``.
+    """
+
+    response = client.responses.create(
+        model="gpt-4.1",
+        instructions=(
+            "Use web browsing to gather today's top world news. "
+            "Return a JSON object with a key 'items' containing a list of "
+            "objects with fields: id (slug), title, date, content, sources."),
+        extra_body={
+            "reasoning": {"effort": "medium"},
+            "dataSources": [{"type": "web"}],
+        },
+    )
+
+    try:
+        payload = json.loads(response.output_text)
+    except Exception:
+        raise RuntimeError("Model response was not valid JSON")
+    return payload.get("items", [])
+
+
 def main() -> None:
-    sample = {
-        "id": "vec_sample",
-        "title": "Przykładowy news",
-        "date": datetime.utcnow().isoformat(),
-        "content": "To jest przykładowy artykuł wygenerowany przez skrypt.",
-        "sources": []
-    }
-    path = os.path.join("news", f"{sample['id']}.json")
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(sample, f, ensure_ascii=False, indent=2)
+    items = fetch_news()
+    os.makedirs("news", exist_ok=True)
+    for item in items:
+        item.setdefault("date", datetime.utcnow().isoformat())
+        path = os.path.join("news", f"{item['id']}.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(item, f, ensure_ascii=False, indent=2)
 
 
 if __name__ == "__main__":

--- a/scripts/update_vector_store.py
+++ b/scripts/update_vector_store.py
@@ -1,0 +1,55 @@
+"""Compute embeddings for news items and update a simple vector store."""
+from __future__ import annotations
+
+import glob
+import json
+import os
+from typing import Any, Dict
+
+from openai import OpenAI
+
+
+client = OpenAI()
+STORE_PATH = "vector_store.json"
+
+
+def load_store() -> Dict[str, Any]:
+    if os.path.exists(STORE_PATH):
+        with open(STORE_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {"items": []}
+
+
+def save_store(store: Dict[str, Any]) -> None:
+    with open(STORE_PATH, "w", encoding="utf-8") as f:
+        json.dump(store, f, ensure_ascii=False, indent=2)
+
+
+def get_embedding(text: str) -> list[float]:
+    resp = client.embeddings.create(
+        model="text-embedding-3-small", input=text
+    )
+    return resp.data[0].embedding
+
+
+def main() -> None:
+    store = load_store()
+    existing_ids = {item["id"] for item in store["items"]}
+
+    for path in glob.glob(os.path.join("news", "*.json")):
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        if data["id"] in existing_ids:
+            continue
+
+        text = f"{data['title']}\n\n{data['content']}"
+        embedding = get_embedding(text)
+        store["items"].append({"id": data["id"], "embedding": embedding})
+
+    save_store(store)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- fetch daily headlines with OpenAI's Deep Research API
- store article embeddings in a simple vector store for later retrieval
- pipeline installs OpenAI SDK, sets API key env, and updates vectors

## Testing
- `python -m py_compile scripts/fetch_news.py scripts/update_vector_store.py`
- `python scripts/fetch_news.py` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*
- `python scripts/update_vector_store.py` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd153db74832082da4efed4e7e1a3