### PR TITLE
Fix daily news fetch by providing input prompt to OpenAI

### DIFF
--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -22,7 +22,7 @@ def fetch_news() -> List[Dict[str, Any]]:
 
     response = client.responses.create(
         model="gpt-4.1",
-        instructions=(
+        input=(
             "Use web browsing to gather today's top world news. "
             "Return a JSON object with a key 'items' containing a list of "
             "objects with fields: id (slug), title, date, content, sources."),


### PR DESCRIPTION
## Summary
- supply `input` instead of `instructions` when calling `client.responses.create`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcdc46e950832080a70829c8de5ba5