### PR TITLE
Use Deep Research API for news fetching

### DIFF
--- a/scripts/fetch_news.py
+++ b/scripts/fetch_news.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List
 from openai import OpenAI
 
 
-client = OpenAI()
+client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
 
 def fetch_news() -> List[Dict[str, Any]]:
@@ -20,22 +20,31 @@ def fetch_news() -> List[Dict[str, Any]]:
     ``sources``.
     """
 
-    response = client.responses.create(
-        model="gpt-4.1",
-        input=(
-            "Use web browsing to gather today's top world news. "
-            "Return a JSON object with a key 'items' containing a list of "
-            "objects with fields: id (slug), title, date, content, sources."),
-        extra_body={
-            "reasoning": {"effort": "medium"},
-            "data_sources": [{"type": "web"}],
-        },
+    system_prompt = (
+        "You are a researcher. Gather today's top news "
+        "and return a JSON object: items list with fields "
+        "id (slug), title, date, content, sources (list of URLs)."
+    )
+    user_prompt = (
+        "Please gather current events and format response in JSON."
     )
 
+    response = client.responses.create(
+        model="o4-mini-deep-research-2025-06-26",
+        input=[
+            {"role": "developer", "content": system_prompt},
+            {"role": "user", "content": user_prompt}
+        ],
+        tools=[{"type": "web_search_preview"}],
+        reasoning={"summary": "auto"}
+    )
+
+    output_text = response.output[-1].content[0].text
     try:
-        payload = json.loads(response.output_text)
-    except Exception:
-        raise RuntimeError("Model response was not valid JSON")
+        payload = json.loads(output_text)
+    except Exception as e:
+        raise RuntimeError(f"Model response was not valid JSON: {e}")
+
     return payload.get("items", [])
 
 
@@ -44,9 +53,11 @@ def main() -> None:
     os.makedirs("news", exist_ok=True)
     for item in items:
         item.setdefault("date", datetime.utcnow().isoformat())
-        path = os.path.join("news", f"{item['id']}.json")
+        fname = f"{item['id']}.json"
+        path = os.path.join("news", fname)
         with open(path, "w", encoding="utf-8") as f:
             json.dump(item, f, ensure_ascii=False, indent=2)
+        print("Saved", path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- refactor `fetch_news.py` to use OpenAI Deep Research with `o4-mini-deep-research-2025-06-26`
- remove unsupported `data_sources` parameter and enable `web_search_preview` tool
- parse JSON response and save fetched news items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd57cfe59c8320b29226783ea94eb7