### PR TITLE
feat: async news fetch with status tracking

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  fetch_news:
     runs-on: ubuntu-latest
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -17,8 +17,23 @@ jobs:
           python-version: '3.x'
       - name: Install dependencies
         run: pip install -r requirements.txt
-      - name: Fetch news
-        run: python scripts/fetch_news.py
+      - name: Start async Deep Research
+        run: python scripts/start_fetch_news_async.py
+
+  build:
+    runs-on: ubuntu-latest
+    needs: fetch_news
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Check async result
+        run: python scripts/check_fetch_news_async.py
       - name: Update vector store
         run: python scripts/update_vector_store.py
       - name: Deduplicate

--- a/scripts/check_fetch_news_async.py
+++ b/scripts/check_fetch_news_async.py
@@ -1,0 +1,98 @@
+import os
+import json
+from datetime import datetime
+from openai import OpenAI
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+
+def _write_status(payload: dict) -> None:
+    with open("status.json", "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+
+
+def main() -> None:
+    if not os.path.exists("pending.txt"):
+        raise RuntimeError("Brak pliku pending.txt \u2014 nie wys\u0142ano zapytania")
+
+    with open("pending.txt", "r", encoding="utf-8") as f:
+        response_id = f.read().strip()
+
+    print(f"\ud83d\udd04 Sprawdzanie statusu dla ID: {response_id}")
+    result = client.responses.retrieve(response_id)
+    print(f"\ud83d\udcca Status: {result.status}")
+
+    if result.status == "in_progress":
+        _write_status(
+            {
+                "status": "in_progress",
+                "response_id": response_id,
+                "updated_at": datetime.utcnow().isoformat(),
+            }
+        )
+        print("\u231b Odpowied\u017a jeszcze si\u0119 generuje. Uruchom ponownie p\u00f3\u017aniej.")
+        raise SystemExit(1)
+
+    if result.status != "completed":
+        _write_status(
+            {
+                "status": "failed",
+                "response_id": response_id,
+                "updated_at": datetime.utcnow().isoformat(),
+                "error": result.status,
+            }
+        )
+        raise RuntimeError(f"\u26d4 \u017badanie zako\u0144czone niepowodzeniem: {result.status}")
+
+    output_text = result.output[-1].content[0].text
+
+    try:
+        payload = json.loads(output_text)
+    except Exception as e:  # pragma: no cover - defensive
+        _write_status(
+            {
+                "status": "failed",
+                "response_id": response_id,
+                "updated_at": datetime.utcnow().isoformat(),
+                "error": "invalid_json",
+            }
+        )
+        raise RuntimeError(f"\u274c Niepoprawny JSON: {e}")
+
+    items = payload.get("items", [])
+    if not items:
+        _write_status(
+            {
+                "status": "failed",
+                "response_id": response_id,
+                "updated_at": datetime.utcnow().isoformat(),
+                "error": "empty_items",
+            }
+        )
+        raise RuntimeError("Brak element\u00f3w w `items`")
+
+    os.makedirs("news", exist_ok=True)
+    for item in items:
+        item.setdefault("date", datetime.utcnow().isoformat())
+        fname = f"{item['id']}.json"
+        path = os.path.join("news", fname)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(item, f, ensure_ascii=False, indent=2)
+        print(f"\u2705 Zapisano news: {fname}")
+
+    os.remove("pending.txt")
+    print("\ud83e\uddf9 Usuni\u0119to pending.txt \u2014 zako\u0144czono cykl.")
+
+    _write_status(
+        {
+            "status": "completed",
+            "response_id": response_id,
+            "updated_at": datetime.utcnow().isoformat(),
+            "items": [item["id"] for item in items],
+        }
+    )
+    print("\ud83d\udcc4 Zaktualizowano status.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/start_fetch_news_async.py
+++ b/scripts/start_fetch_news_async.py
@@ -1,0 +1,53 @@
+import os
+import json
+from datetime import datetime
+from openai import OpenAI
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+
+def main() -> None:
+    """Send async Deep Research request and store response ID."""
+    print("\u23f3 Wysy\u0142anie zapytania do Deep Research...")
+
+    response = client.responses.create(
+        model="o3-deep-research-2025-06-26",
+        input=[
+            {
+                "role": "developer",
+                "content": (
+                    "Zbierz dzisiejsze wydarzenia z Polski, Europy i świata. "
+                    "Zwr\u00f3\u0107 dane w formacie JSON z kluczem `items`: lista obiekt\u00f3w zawieraj\u0105cych "
+                    "`id` (slug), `title`, `date`, `content`, `sources` (lista link\u00f3w)."
+                ),
+            },
+            {
+                "role": "user",
+                "content": "Wygeneruj podsumowanie wydarze\u0144 na dzi\u015b w formacie JSON.",
+            },
+        ],
+        tools=[{"type": "web_search_preview"}],
+        reasoning={"summary": "auto"},
+        stream=False,
+        polling={"method": "status_endpoint"},
+    )
+
+    response_id = response.id
+    print(f"\u2705 Zapytanie wys\u0142ane. ID: {response_id}")
+
+    with open("pending.txt", "w", encoding="utf-8") as f:
+        f.write(response_id)
+    print("\ud83d\udcdd Zapisano response_id do pending.txt")
+
+    status_payload = {
+        "status": "pending",
+        "response_id": response_id,
+        "updated_at": datetime.utcnow().isoformat(),
+    }
+    with open("status.json", "w", encoding="utf-8") as f:
+        json.dump(status_payload, f, ensure_ascii=False, indent=2)
+    print("\ud83d\udcc4 Zaktualizowano status.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/status.json
+++ b/status.json
@@ -1,0 +1,4 @@
+{
+  "status": "idle",
+  "updated_at": null
+}


### PR DESCRIPTION
## Summary
- add async Deep Research scripts to queue and retrieve news
- write status.json tracking fetch progress and results
- run async start and check steps in CI pipeline

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd722d5a848320a87ccae459e123ac